### PR TITLE
Iteritems for iterating through pandas

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,6 @@
   :scm {:name "git" :url "https://github.com/alanmarazzi/panthera"}
   :license {:name "EPL-2.0"
             :url  "https://www.eclipse.org/legal/epl-2.0/"}
-  :dependencies [[cnuernber/libpython-clj "0.12"]
+  :dependencies [[cnuernber/libpython-clj "0.13"]
                  [org.clojure/core.memoize "0.7.2"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.1"]]}})


### PR DESCRIPTION
* Added multimethod for overriding the `Iterable` implementation of `.iterator`.  This makes `:series` and `:data-frame` objects behave correctly in terms of 'vec', 'seq' and friends.

Python in general is confused here.  They have both `__iter__` and `iteritems` and when to use either or if either even exist isn't totally clear to me.

It could be that correct usage is to use 'iteritems' if it exists and '__iter__' if not; just not sure yet.  So the multimethod allows mistakes here to be fixed on python-object-type basis.