### PR TITLE
Add support for `sort_values` function

### DIFF
--- a/src/panthera/pandas/generics.clj
+++ b/src/panthera/pandas/generics.clj
@@ -795,8 +795,6 @@
   [df-or-srs & [attrs]]
   (u/simple-kw-call df-or-srs "sort_values" attrs))
 
-(sort-values (series [2 3 1]))
-
 (defn- preds
   "Dispatcher to avoid repetition"
   [k]

--- a/src/panthera/pandas/generics.clj
+++ b/src/panthera/pandas/generics.clj
@@ -749,18 +749,14 @@
 
   - `df-or-srs` -> data-frame, series
 
-  **Attrs**
-
-  - For data-frame: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.sort_values.html#pandas.DataFrame.sort_values
-  - For series: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.sort_values.html
-  - For index: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Index.sort_values.html
-
   **Commonly Used Attrs**
 
   - `by`* -> keyword, str, or vector of keywords or strs, the name or list of names to sort by.
   - `:ascending` -> bool, default: true
 
   * Only for data-frames.
+
+  _For additional attributes, see Pandas documentation (links below)._
 
   **Examples**
 
@@ -789,7 +785,13 @@
   ; 2   4  3
   ; 1  20  2
 
-  ```"
+  ```
+
+  **Pandas documentation**
+
+  - For data-frame: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.sort_values.html#pandas.DataFrame.sort_values
+  - For series: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.sort_values.html
+  - For index: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Index.sort_values.html"
   [df-or-srs & [attrs]]
   (u/simple-kw-call df-or-srs "sort_values" attrs))
 

--- a/src/panthera/pandas/generics.clj
+++ b/src/panthera/pandas/generics.clj
@@ -783,53 +783,48 @@
 (defn sort-values
   "Sort values in a series or along any axis in a data-frame, series or index.
 
-  **Arguments**
+  Arguments:
 
-  - `df-or-srs` -> data-frame, series
+    - `df-or-srs` -> data-frame, series
 
-  **Commonly Used Attrs**
+  Commonly Used Attrs:
 
-  - `by`* -> keyword, str, or vector of keywords or strs, the name or list of names to sort by.
-  - `:ascending` -> bool, default: true
+    - `by` -> (data-frame only) keyword, str, or vector of keywords or strs; the name or list of names to sort by.
+    - `ascending` -> bool, default: true; sort ascending vs. descending
 
-  * Only for data-frames.
+    For additional attributes, see Pandas documentation (links below).
 
-  _For additional attributes, see Pandas documentation (links below)._
+  Examples`:
 
-  **Examples**
+    (sort-values (series [2 20 4]))
+    ; 0     2
+    ; 2     4
+    ; 1    20
+    ; dtype: int64
 
-  ```
-  (sort-values (series [2 20 4]))
-  ; 0     2
-  ; 2     4
-  ; 1    20
-  ; dtype: int64
+    (sort-values (series [2 20 4]) {:ascending false})
+    ; 1    20
+    ; 2     4
+    ; 0     2
+    ; dtype: int64
 
-  (sort-values (series [2 20 4]) {:ascending false})
-  ; 1    20
-  ; 2     4
-  ; 0     2
-  ; dtype: int64
+    (data-frame [{:a 2 :b 1} {:a 20 :b 2} {:a 4 :b 3}])
+    ;     a  b
+    ; 0   2  1
+    ; 1  20  2
+    ; 2   4  3
 
-  (data-frame [{:a 2 :b 1} {:a 20 :b 2} {:a 4 :b 3}])
-  ;     a  b
-  ; 0   2  1
-  ; 1  20  2
-  ; 2   4  3
-
-  (sort-values df {:by :a})
-  ;     a  b
-  ; 0   2  1
-  ; 2   4  3
-  ; 1  20  2
-
-  ```
+    (sort-values df {:by :a})
+    ;     a  b
+    ; 0   2  1
+    ; 2   4  3
+    ; 1  20  2
 
   **Pandas documentation**
 
-  - For data-frame: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.sort_values.html#pandas.DataFrame.sort_values
-  - For series: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.sort_values.html
-  - For index: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Index.sort_values.html"
+    - For data-frame: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.sort_values.html#pandas.DataFrame.sort_values
+    - For series: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.sort_values.html
+    - For index: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Index.sort_values.html"
   [df-or-srs & [attrs]]
   (u/simple-kw-call df-or-srs "sort_values" attrs))
 

--- a/src/panthera/pandas/generics.clj
+++ b/src/panthera/pandas/generics.clj
@@ -742,7 +742,6 @@
   [df-or-srs & [attrs]]
   (u/simple-kw-call df-or-srs "nunique" attrs))
 
-
 (defn- preds
   "Dispatcher to avoid repetition"
   [k]

--- a/src/panthera/pandas/generics.clj
+++ b/src/panthera/pandas/generics.clj
@@ -742,6 +742,44 @@
   [df-or-srs & [attrs]]
   (u/simple-kw-call df-or-srs "nunique" attrs))
 
+
+(defn- preds
+  "Dispatcher to avoid repetition"
+  [k]
+  (fn [seq-or-srs]
+    (let [ks {:unique?     #(py/get-attr % "is_unique")
+              :increasing? #(py/get-attr % "is_monotonic_increasing")
+              :decreasing? #(py/get-attr % "is_monotonic_decreasing")}]
+      (if (u/series? seq-or-srs)
+        ((ks k) seq-or-srs)
+        (recur (series seq-or-srs))))))
+
+(def unique?
+  "Return wether the values in the given collection are unique.
+
+  **Arguments**
+
+  - `seq-or-srs` -> seqable or series
+
+  **Examples**
+
+  ```
+  (unique? [1 2 3])
+  ;true
+
+  (unique? (series [1 1 2]))
+  ;false
+  ```"
+  (preds :unique?))
+
+(def increasing?
+  "Equivalent to Clojure's `<`"
+  (preds :increasing?))
+
+(def decreasing?
+  "Equivalent to Clojure's `>`"
+  (preds :decreasing?))
+
 (defn sort-values
   "Sort values in a series or along any axis in a data-frame, series or index.
 
@@ -794,45 +832,6 @@
   - For index: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Index.sort_values.html"
   [df-or-srs & [attrs]]
   (u/simple-kw-call df-or-srs "sort_values" attrs))
-
-(defn- preds
-  "Dispatcher to avoid repetition"
-  [k]
-  (fn [seq-or-srs]
-    (let [ks {:unique?     #(py/get-attr % "is_unique")
-              :increasing? #(py/get-attr % "is_monotonic_increasing")
-              :decreasing? #(py/get-attr % "is_monotonic_decreasing")}]
-      (if (u/series? seq-or-srs)
-        ((ks k) seq-or-srs)
-        (recur (series seq-or-srs))))))
-
-
-
-(def unique?
-  "Return wether the values in the given collection are unique.
-
-  **Arguments**
-
-  - `seq-or-srs` -> seqable or series
-
-  **Examples**
-
-  ```
-  (unique? [1 2 3])
-  ;true
-
-  (unique? (series [1 1 2]))
-  ;false
-  ```"
-  (preds :unique?))
-
-(def increasing?
-  "Equivalent to Clojure's `<`"
-  (preds :increasing?))
-
-(def decreasing?
-  "Equivalent to Clojure's `>`"
-  (preds :decreasing?))
 
 (defn value-counts
   "Return the count of all unique values

--- a/src/panthera/pandas/generics.clj
+++ b/src/panthera/pandas/generics.clj
@@ -742,6 +742,59 @@
   [df-or-srs & [attrs]]
   (u/simple-kw-call df-or-srs "nunique" attrs))
 
+(defn sort-values
+  "Sort values in a series or along any axis in a data-frame, series or index.
+
+  **Arguments**
+
+  - `df-or-srs` -> data-frame, series
+
+  **Attrs**
+
+  - For data-frame: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.sort_values.html#pandas.DataFrame.sort_values
+  - For series: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.sort_values.html
+  - For index: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Index.sort_values.html
+
+  **Commonly Used Attrs**
+
+  - `by`* -> keyword, str, or vector of keywords or strs, the name or list of names to sort by.
+  - `:ascending` -> bool, default: true
+
+  * Only for data-frames.
+
+  **Examples**
+
+  ```
+  (sort-values (series [2 20 4]))
+  ; 0     2
+  ; 2     4
+  ; 1    20
+  ; dtype: int64
+
+  (sort-values (series [2 20 4]) {:ascending false})
+  ; 1    20
+  ; 2     4
+  ; 0     2
+  ; dtype: int64
+
+  (data-frame [{:a 2 :b 1} {:a 20 :b 2} {:a 4 :b 3}])
+  ;     a  b
+  ; 0   2  1
+  ; 1  20  2
+  ; 2   4  3
+
+  (sort-values df {:by :a})
+  ;     a  b
+  ; 0   2  1
+  ; 2   4  3
+  ; 1  20  2
+
+  ```"
+  [df-or-srs & [attrs]]
+  (u/simple-kw-call df-or-srs "sort_values" attrs))
+
+(sort-values (series [2 3 1]))
+
 (defn- preds
   "Dispatcher to avoid repetition"
   [k]
@@ -752,6 +805,8 @@
       (if (u/series? seq-or-srs)
         ((ks k) seq-or-srs)
         (recur (series seq-or-srs))))))
+
+
 
 (def unique?
   "Return wether the values in the given collection are unique.

--- a/test/panthera/generics_test.clj
+++ b/test/panthera/generics_test.clj
@@ -237,6 +237,18 @@
     [3 3 3] true
     [1 2 3] false))
 
+(deftest sort-values
+  (are [i attrs o]
+      (= o (vec (g/sort-values i attrs)))
+    (g/series []) {} []
+    (g/series [20 1 4]) {} [1 4 20]
+    (g/series [20 1 4]) {:ascending false} [20 4 1]
+    (g/series ["foo" "bar"]) {} ["bar" "foo"]
+    (g/series [:b :c :a]) {} ["a" "b" "c"])
+  (are [i col attrs o]
+      (= o (-> i (g/sort-values attrs) (g/subset-cols :a) vec))
+    (g/data-frame [{:a 20} {:a 1} {:a 4}]) :a {:by :a} [1 4 20]))
+
 (deftest value-counts
   (are [i m o]
        (= (g/value-counts i (merge {:clj true} m)) o)


### PR DESCRIPTION
Adds support for Pandas' `sort_values` function. The syntax is similar to other functions that do not take any positional arguments by default -- apart from the data object itself of course:

```clj
(sort-values df-or-srs & [attrs])
```
For the doc string, I added a few commonly used attributes and the linked the original Pandas docs. 

Questions/Thoughts:  

* Is the way I added the links to the docs for the pandas docstring appropriate and is it clear to someone who may be unfamiliar?

Fixes #8 
